### PR TITLE
Correct terminal command in CHAPTER-10.MD

### DIFF
--- a/lessons/chapter-10/CHAPTER-10.MD
+++ b/lessons/chapter-10/CHAPTER-10.MD
@@ -31,7 +31,7 @@ ldnRBAE39QwyGwkQoxWhmo+Sl9F4zA==
 ### Switching between identities
 To check the current used identity, execute:
 ```bash
-$ dfx identity whoamis 
+$ dfx identity whoami
 ```
 To view other available identities, run:
 ```bash


### PR DESCRIPTION
The terminal command to display the current dfx identity was corrected.

@seb-icp 